### PR TITLE
Add cl-lib dependency

### DIFF
--- a/vertigo.el
+++ b/vertigo.el
@@ -44,6 +44,7 @@
 
 ;;; Code:
 (require 'dash)
+(require 'cl-lib)
 
 (defgroup vertigo nil
   "Gives commands for moving by lines using the home row."


### PR DESCRIPTION
The missing dependency causes problems when using straight.el instead of the builtin package.el. Not exactly sure why as both depend on cl-lib.